### PR TITLE
Use right case for WildFly name

### DIFF
--- a/about.html
+++ b/about.html
@@ -10,7 +10,7 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <title>Wildfly Model Reference</title>
+    <title>WildFly Model Reference</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width">
 
@@ -40,7 +40,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" href="https://wildscribe.github.io/index.html">Wildfly Model Reference</a>
+            <a class="navbar-brand" href="https://wildscribe.github.io/index.html">WildFly Model Reference</a>
         </div>
         <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
@@ -49,19 +49,19 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">Versions<b class="caret"></b></a>
                     <ul class="dropdown-menu">
                             <li class=" ">
-                                <a href="https://wildscribe.github.io/Wildfly/10.0.0.Final/index.html">Wildfly
+                                <a href="https://wildscribe.github.io/Wildfly/10.0.0.Final/index.html">WildFly
                                 10.0.0.Final</a></li>
                             <li class=" ">
-                                <a href="https://wildscribe.github.io/Wildfly/9.0.0.Final/index.html">Wildfly
+                                <a href="https://wildscribe.github.io/Wildfly/9.0.0.Final/index.html">WildFly
                                 9.0.0.Final</a></li>
                             <li class=" ">
-                                <a href="https://wildscribe.github.io/Wildfly/8.2.0.Final/index.html">Wildfly
+                                <a href="https://wildscribe.github.io/Wildfly/8.2.0.Final/index.html">WildFly
                                 8.2.0.Final</a></li>
                             <li class=" ">
-                                <a href="https://wildscribe.github.io/Wildfly/8.1.0.Final/index.html">Wildfly
+                                <a href="https://wildscribe.github.io/Wildfly/8.1.0.Final/index.html">WildFly
                                 8.1.0.Final</a></li>
                             <li class=" ">
-                                <a href="https://wildscribe.github.io/Wildfly/8.0.0.Final/index.html">Wildfly
+                                <a href="https://wildscribe.github.io/Wildfly/8.0.0.Final/index.html">WildFly
                                 8.0.0.Final</a></li>
                             <li class=" ">
                                 <a href="https://wildscribe.github.io/JBoss%20EAP/6.4.0/index.html">JBoss EAP
@@ -90,7 +90,7 @@
                     </ul>
                 </li>
                 <li><a href="http://www.jboss.com">Get JBoss EAP</a></li>
-                <li><a href="http://www.wildfly.org">Get Wildfly</a></li>
+                <li><a href="http://www.wildfly.org">Get WildFly</a></li>
                 <li class="active"><a href="https://wildscribe.github.io/about.html">About</a></li>
 
             </ul>
@@ -100,9 +100,9 @@
 </div>
 
 <div class="container">
-    <h1>Wildfly Model Reference Documentation</h1>
+    <h1>WildFly Model Reference Documentation</h1>
 
-    <p>This site contains automatically generated documentation about the Wildfly, JBoss EAP and JBoss AS7 application servers.</p>
+    <p>This site contains automatically generated documentation about the WildFly, JBoss EAP and JBoss AS7 application servers.</p>
 </div>
 <div class="container">
     <hr>


### PR DESCRIPTION
This commit uses the correct case for the WildFly server references.
